### PR TITLE
Add improved reputation factors

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,52 @@ Start monitoring:
 python main.py start
 ```
 
+Continuous monitoring:
+
+```bash
+python main.py monitor --interval 60
+```
+
 Display stored events:
 
 ```bash
 python main.py events
 ```
+
+Check the reputation of an IP, domain, URL, or file:
+
+```bash
+python main.py check --ip 8.8.8.8
+python main.py check --domain example.com
+python main.py check --url https://example.com/big.jpg
+    python main.py check --file /path/to/file.exe
+```
+
+### Configuration
+
+The `~/.lucky7/config.yml` file contains reputation settings. You can provide
+API keys for VirusTotal or AlienVault OTX and adjust how long reputation history
+is stored:
+
+```yaml
+reputation:
+  api_key: "YOUR_VT_KEY"
+  otx_api_key: "YOUR_OTX_KEY"
+  ipinfo_token: "YOUR_IPINFO_TOKEN"
+  abuseipdb_key: "YOUR_ABUSEIPDB_KEY"
+  method: virustotal  # or 'otx', 'abuseipdb', 'geofencing', 'heuristic'
+  history_retention_days: 30
+  large_image_threshold_mb: 100
+```
+
+Heuristic lookups consider multiple factors:
+* IP address characteristics such as private or reserved ranges, hosting
+  providers, VPN/TOR indicators (via ipinfo), and country-based geofencing.
+* Domain traits including age, risky top-level domains, punycode or very long
+  names, digits or hyphens, and repeated characters.
+* File reputation based on extension types commonly used for malware or office
+  documents with macros when no external service is used.
+
+* URL checks flag unencrypted links and images larger than the configured threshold.
+* Processes named like telemetry or analytics with outbound traffic are logged with encryption status.
 

--- a/config.py
+++ b/config.py
@@ -15,7 +15,9 @@ DEFAULT_CONFIG = {
         #Processes that should normally be ignored.
         "process_whitelist": ["systemd","init","bash","python","gnome-shell","Xorg","kworker"],
         #New: CPU usage threshold ( in percent) above which a kworker process is flagged
-        "kworker_cpu_threshold": 20
+        "kworker_cpu_threshold": 20,
+        # Keywords indicating telemetry related processes
+        "telemetry_keywords": ["telemetry", "metrics", "analytics", "report", "tracking"],
     },
     "database": {
         "path": os.path.join(CONFIG_DIR, "lucky7.db")
@@ -24,12 +26,22 @@ DEFAULT_CONFIG = {
         "level": "INFO"
     },
     "reputation": {
-        "api_key": "", # If provided, VirusTotal will be used.
+        "api_key": "",       # VirusTotal API key
+        "otx_api_key": "",   # AlienVault OTX API key
+        "ipinfo_token": "",  # Optional ipinfo.io token for IP reputation
+        "abuseipdb_key": "", # Optional AbuseIPDB API key
 
-        # Either "virustotal" (if key provided) or fallback "geofencing".
+        # Method to use for lookups: 'virustotal', 'otx', 'abuseipdb',
+        # 'geofencing', or 'heuristic' (simple scoring based on IP location).
         "method": "geofencing",
+
         # For geofencing: trusted if IP is located in this country.
-        "geofence_country": "United States"
+        "geofence_country": "United States",
+
+        # Retain reputation history for this many days
+        "history_retention_days": 30,
+        # Flag images larger than this many MB when checking URLs
+        "large_image_threshold_mb": 100
     }
 }
 

--- a/reputation.py
+++ b/reputation.py
@@ -1,80 +1,329 @@
 import requests
+from datetime import datetime
+import os
+import ipaddress
+from urllib.parse import urlparse
+import db
 
-def get_ip_reputation(ip, config):
-    """
-    Checks the reputation of an IP address.
-    If a VirusTotal API key is provided and method is set to 'virustotal', queries VirusTotal.
-    Otherwise, uses a geolocation API to determine if the IP is in the trusted country.
-    
-    Returns a tuple: (status, details)
-      - status: "Trusted" or "Untrusted" (or "Unknown" if lookup fails)
-      - details: A string with lookup details.
-    """
-    rep_config = config.get("reputation", {})
-    api_key = rep_config.get("api_key", "").strip()
-    method = rep_config.get("method", "geofencing").lower()
-    
-    if api_key and method == "virustotal":
-        url = f"https://www.virustotal.com/api/v3/ip_addresses/{ip}"
-        headers = {"x-apikey": api_key}
-        try:
-            response = requests.get(url, headers=headers, timeout=10)
-            if response.status_code == 200:
-                data = response.json()
-                # In VT v3, a negative reputation score may indicate malicious behavior.
-                attributes = data.get("data", {}).get("attributes", {})
-                reputation_score = attributes.get("reputation", 0)
-                # Simple heuristic: negative score => untrusted.
-                status = "Untrusted" if reputation_score < 0 else "Trusted"
-                details = f"VirusTotal reputation score: {reputation_score}"
-                return status, details
-            else:
-                # Fall through to geofencing if API fails.
-                pass
-        except Exception as e:
-            # On error, fallback to geofencing.
-            pass
 
-    # Fallback to geofencing using ip-api.com
+def map_score_to_state(score: int) -> str:
+    """Converts a 0-100 score into a textual state."""
+    if score >= 80:
+        return "Trusted"
+    if score >= 50:
+        return "Suspicious"
+    if score >= 0:
+        return "Malicious"
+    return "Unknown"
+
+
+def store_history(entity, entity_type, status, details, config):
+    retention = config.get("reputation", {}).get("history_retention_days", 30)
+    db.insert_reputation_history(entity, entity_type, status, details)
+    db.purge_old_history(retention)
+
+
+# --- External lookup helpers -------------------------------------------------
+
+def _virustotal_lookup(endpoint: str, api_key: str):
+    headers = {"x-apikey": api_key}
+    response = requests.get(endpoint, headers=headers, timeout=10)
+    if response.status_code == 200:
+        return response.json()
+    return None
+
+
+def _otx_lookup(url: str, api_key: str):
+    headers = {"X-OTX-API-KEY": api_key}
+    response = requests.get(url, headers=headers, timeout=10)
+    if response.status_code == 200:
+        return response.json()
+    return None
+
+
+def _ipinfo_lookup(ip: str, token: str = ""):
+    url = f"https://ipinfo.io/{ip}/json"
+    if token:
+        url += f"?token={token}"
+    response = requests.get(url, timeout=5)
+    if response.status_code == 200:
+        return response.json()
+    return None
+
+
+def _abuseipdb_lookup(ip: str, api_key: str):
+    url = (
+        f"https://api.abuseipdb.com/api/v2/check?ipAddress={ip}&maxAgeInDays=90"
+    )
+    headers = {"Key": api_key, "Accept": "application/json"}
+    response = requests.get(url, headers=headers, timeout=10)
+    if response.status_code == 200:
+        return response.json()
+    return None
+
+
+def _domain_age(domain: str):
     try:
-        geo_url = f"http://ip-api.com/json/{ip}"
-        response = requests.get(geo_url, timeout=5)
-        if response.status_code == 200:
-            data = response.json()
-            country = data.get("country", "Unknown")
-            trusted_country = rep_config.get("geofence_country", "United States")
-            status = "Trusted" if country == trusted_country else "Untrusted"
-            details = f"Country: {country}"
-            return status, details
-        else:
-            return "Unknown", "Geofencing lookup failed"
-    except Exception as e:
-        return "Unknown", f"Error: {str(e)}"
+        resp = requests.get(f"https://api.whois.vu/?q={domain}", timeout=10)
+        if resp.status_code == 200:
+            data = resp.json()
+            created = data.get("created")
+            if created:
+                created_dt = datetime.utcfromtimestamp(int(created))
+                return (datetime.utcnow() - created_dt).days
+    except Exception:
+        pass
+    return None
 
-def get_event_reputation(connections_str, config):
-    """
-    Given a comma-separated string of connections (in the format "IP:port, IP:port, ..."),
-    checks the reputation of each IP and aggregates the results.
-    
-    Returns a tuple: (overall_status, aggregated_details)
-      - overall_status: "Trusted" if all connections are trusted, otherwise "Untrusted"
-      - aggregated_details: A semicolon-separated string of per-IP reputation details.
-    
-    If there are no connections, returns ("Trusted", "").
-    """
+
+# --- Reputation checks -------------------------------------------------------
+
+def get_ip_reputation(ip: str, config):
+    rep_config = config.get("reputation", {})
+    vt_key = rep_config.get("api_key", "").strip()
+    otx_key = rep_config.get("otx_api_key", "").strip()
+    abuse_key = rep_config.get("abuseipdb_key", "").strip()
+    method = rep_config.get("method", "geofencing").lower()
+
+    details = ""
+    score = 50
+
+    if method == "virustotal" and vt_key:
+        data = _virustotal_lookup(f"https://www.virustotal.com/api/v3/ip_addresses/{ip}", vt_key)
+        if data:
+            rep = data.get("data", {}).get("attributes", {}).get("reputation", 0)
+            score = 80 if rep >= 0 else 20
+            details = f"VirusTotal reputation score: {rep}"
+    elif method == "otx" and otx_key:
+        data = _otx_lookup(f"https://otx.alienvault.com/api/v1/indicators/IPv4/{ip}/general", otx_key)
+        if data:
+            pulses = data.get("pulse_info", {}).get("count", 0)
+            score = 20 if pulses > 0 else 80
+            details = f"OTX pulses: {pulses}"
+    elif method == "abuseipdb" and abuse_key:
+        data = _abuseipdb_lookup(ip, abuse_key)
+        if data:
+            abuse_score = data.get("data", {}).get("abuseConfidenceScore", 0)
+            score = 100 - abuse_score
+            details = f"AbuseIPDB score: {abuse_score}"
+    else:
+        try:
+            ip_obj = ipaddress.ip_address(ip)
+            if ip_obj.is_private:
+                score = 90
+                details = "Private IP"
+            elif ip_obj.is_reserved or ip_obj.is_loopback or ip_obj.is_multicast:
+                score = 90
+                details = "Reserved/Loopback IP"
+            else:
+                response = requests.get(f"http://ip-api.com/json/{ip}", timeout=5)
+                if response.status_code == 200:
+                    country = response.json().get("country", "Unknown")
+                    trusted = rep_config.get("geofence_country", "United States")
+                    score = 80 if country == trusted else 40
+                    details = f"Country: {country}"
+                else:
+                    details = "Geofencing lookup failed"
+
+                # hosting provider check via ipinfo
+                token = rep_config.get("ipinfo_token", "")
+                info = _ipinfo_lookup(ip, token)
+                if info:
+                    org = info.get("org", "").lower()
+                    if any(p in org for p in ["amazon", "digitalocean", "google", "microsoft", "ovh", "cloud"]):
+                        score -= 20
+                        details += f"; Hosting: {org}"
+                    privacy = info.get("privacy", {})
+                    if any(privacy.get(k) for k in ["vpn", "proxy", "tor"]):
+                        score -= 30
+                        flags = ",".join([k for k in ["vpn", "proxy", "tor"] if privacy.get(k)])
+                        details += f"; Privacy: {flags}"
+        except Exception as e:
+            details = f"Error: {e}"
+
+    status = map_score_to_state(score)
+    store_history(ip, "ip", status, details, rep_config)
+    return status, details
+
+
+def get_domain_reputation(domain: str, config):
+    rep_config = config.get("reputation", {})
+    vt_key = rep_config.get("api_key", "")
+    otx_key = rep_config.get("otx_api_key", "")
+    method = rep_config.get("method", "geofencing").lower()
+
+    details = ""
+    score = 50
+
+    if method == "virustotal" and vt_key:
+        data = _virustotal_lookup(f"https://www.virustotal.com/api/v3/domains/{domain}", vt_key)
+        if data:
+            malicious = data.get("data", {}).get("attributes", {}).get("last_analysis_stats", {}).get("malicious", 0)
+            score = 20 if malicious else 80
+            details = f"VirusTotal malicious count: {malicious}"
+    elif method == "otx" and otx_key:
+        data = _otx_lookup(f"https://otx.alienvault.com/api/v1/indicators/domain/{domain}/general", otx_key)
+        if data:
+            pulses = data.get("pulse_info", {}).get("count", 0)
+            score = 20 if pulses > 0 else 80
+            details = f"OTX pulses: {pulses}"
+    else:
+        tld = domain.split(".")[-1].lower()
+        if any(x in domain for x in ["malware", "phish", "spam"]):
+            score = 30
+            details = "Domain contains suspicious keywords"
+        elif domain.endswith(".gov") or domain.endswith(".edu"):
+            score = 85
+            details = "Government/Education domain"
+        else:
+            score = 70
+            details = "Generic domain"
+
+        if domain.startswith("xn--"):
+            score -= 15
+            details += "; Punycode"
+        if len(domain) > 25:
+            score -= 5
+            details += "; Long"
+        if any(ch * 3 in domain for ch in set(domain)):
+            score -= 5
+            details += "; Repeated chars"
+
+        age = _domain_age(domain)
+        if age is not None:
+            if age < 365:
+                score -= 20
+                details += f"; Age {age}d"
+            elif age > 1825:
+                score += 10
+                details += f"; Age {age}d"
+        if tld in ["ru", "cn", "xyz", "top", "info", "club"]:
+            score -= 10
+            details += "; Risky TLD"
+        if any(char.isdigit() for char in domain):
+            score -= 5
+            details += "; Contains digits"
+        if "-" in domain:
+            score -= 5
+            details += "; Contains hyphen"
+
+    status = map_score_to_state(score)
+    store_history(domain, "domain", status, details, rep_config)
+    return status, details
+
+
+def get_file_reputation(file_hash: str, config, file_path: str | None = None):
+    rep_config = config.get("reputation", {})
+    vt_key = rep_config.get("api_key", "")
+    otx_key = rep_config.get("otx_api_key", "")
+    method = rep_config.get("method", "geofencing").lower()
+
+    details = ""
+    score = 50
+
+    if method == "virustotal" and vt_key:
+        data = _virustotal_lookup(f"https://www.virustotal.com/api/v3/files/{file_hash}", vt_key)
+        if data:
+            malicious = data.get("data", {}).get("attributes", {}).get("last_analysis_stats", {}).get("malicious", 0)
+            score = 20 if malicious else 80
+            details = f"VirusTotal malicious count: {malicious}"
+    elif method == "otx" and otx_key:
+        data = _otx_lookup(f"https://otx.alienvault.com/api/v1/indicators/file/{file_hash}/general", otx_key)
+        if data:
+            pulses = data.get("pulse_info", {}).get("count", 0)
+            score = 20 if pulses > 0 else 80
+            details = f"OTX pulses: {pulses}"
+    else:
+        score = 60
+        details = "No external reputation lookup"
+        if file_path:
+            ext = os.path.splitext(file_path)[1].lower()
+            if ext in [
+                ".exe",
+                ".dll",
+                ".bat",
+                ".cmd",
+                ".js",
+                ".vbs",
+                ".scr",
+                ".jar",
+                ".ps1",
+                ".sh",
+                ".py",
+            ]:
+                score -= 10
+                details += f"; Extension {ext}"
+            elif ext in [
+                ".pdf",
+                ".doc",
+                ".docx",
+                ".xls",
+                ".xlsx",
+                ".ppt",
+                ".pptx",
+            ]:
+                score -= 5
+                details += f"; Possible macro {ext}"
+            try:
+                size = os.path.getsize(file_path)
+                if size < 1024:
+                    score -= 5
+                    details += f"; Size {size}B"
+            except OSError:
+                pass
+
+    status = map_score_to_state(score)
+    store_history(file_hash, "file", status, details, rep_config)
+    return status, details
+
+
+def get_url_reputation(url: str, config):
+    """Evaluate a URL for reputation issues such as large image downloads."""
+    rep_config = config.get("reputation", {})
+    threshold = rep_config.get("large_image_threshold_mb", 100)
+    details = ""
+    score = 50
+    try:
+        resp = requests.head(url, allow_redirects=True, timeout=10)
+        if resp.status_code >= 400:
+            score -= 20
+            details += f"HTTP {resp.status_code}; "
+        length = int(resp.headers.get("Content-Length", "0"))
+        ctype = resp.headers.get("Content-Type", "").lower()
+        is_image = "image" in ctype
+        if length > threshold * 1024 * 1024 and is_image:
+            score -= 40
+            details += f"Image {length // (1024*1024)}MB; "
+        if resp.url.startswith("http://"):
+            score -= 10
+            details += "Unencrypted HTTP; "
+        domain = urlparse(resp.url).hostname
+        if domain:
+            dom_status, _ = get_domain_reputation(domain, config)
+            if dom_status == "Malicious":
+                score = 10
+                details += "Domain malicious; "
+    except Exception as e:
+        return "Unknown", f"Error: {e}"
+
+    details = details.strip().rstrip(";")
+    status = map_score_to_state(score)
+    store_history(url, "url", status, details, rep_config)
+    return status, details
+
+
+def get_event_reputation(connections_str: str, config):
     if not connections_str:
         return "Trusted", ""
-    
+
     ips = [conn.strip().split(":")[0] for conn in connections_str.split(",") if conn.strip()]
     statuses = []
     details_list = []
-    
     for ip in ips:
         status, details = get_ip_reputation(ip, config)
         statuses.append(status)
         details_list.append(f"{ip}: {details}")
-    
+
     overall = "Trusted" if all(s == "Trusted" for s in statuses) else "Untrusted"
     aggregated_details = "; ".join(details_list)
     return overall, aggregated_details
-


### PR DESCRIPTION
## Summary
- expand reputation config with optional ipinfo token
- document new heuristics for reputation checks
- improve IP lookup by factoring private ranges and hosting providers
- score domains with age, TLD risk, and character heuristics
- include file extension heuristics in file reputation
- add URL reputation checks and telemetry detection with encryption status

## Testing
- `python -m py_compile main.py config.py db.py process_monitor.py reputation.py`
- `python main.py --help | head -n 20`
- `python main.py check --help`
- `python main.py init`
- `python main.py start`
- `python main.py monitor --interval 1 & sleep 3; kill $!`
- `python main.py events --limit 5`
- `python main.py check --ip 8.8.8.8`
- `echo test > /tmp/test.exe && python main.py check --file /tmp/test.exe`
- `python main.py check --url https://example.com`
- `python - <<'PY'
import db
print(db.fetch_reputation_history(limit=5))
PY`


------
https://chatgpt.com/codex/tasks/task_e_686786b04140832788656861a65f5257