### PR TITLE
Fix CLI parser duplication and retention config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM ubuntu:22.04
-CMD ["echo", "Hello, World!"]
-
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+ENTRYPOINT ["python", "main.py"]

--- a/main.py
+++ b/main.py
@@ -178,9 +178,6 @@ def main():
     group.add_argument("--domain", type=str, help="Domain to lookup")
     group.add_argument("--url", type=str, help="URL to lookup")
     group.add_argument("--file", type=str, help="File path to lookup (SHA256 will be calculated)")
-    # Command to score a website for phishing risk
-    score_parser = subparsers.add_parser("score", help="Score a website for phishing risk")
-    score_parser.add_argument("url", help="URL to evaluate")
     
     args = parser.parse_args()
     

--- a/reputation.py
+++ b/reputation.py
@@ -18,7 +18,7 @@ def map_score_to_state(score: int) -> str:
 
 
 def store_history(entity, entity_type, status, details, config):
-    retention = config.get("reputation", {}).get("history_retention_days", 30)
+    retention = config.get("history_retention_days", 30)
     db.insert_reputation_history(entity, entity_type, status, details)
     db.purge_old_history(retention)
 


### PR DESCRIPTION
## Summary
- remove duplicate `score` command definition
- store history retention directly from passed config
- build runnable container that installs requirements

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68679e3612688327b2b13439978cde28