### PR TITLE
Add reverse shell simulation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # lucky7 | Lightweight on-host monitoring tool
 ---------
 lightweight on-host monitoring tool that tracks suspicious local activity
+
+> **Disclaimer**: Lucky7 is intended for authorized training and defensive simulation only. Do not use it for malicious purposes.
 __________________________________________________________________________
 python main.py init -- Generates Required Configuration Files
 
@@ -63,6 +65,31 @@ python main.py check --url https://example.com/big.jpg
     python main.py check --file /path/to/file.exe
 ```
 
+## Training server
+
+These routes simulate attacker behavior for defensive research. Data such as browser fingerprints and login attempts are stored for analysis.
+
+Start the web server with honeypot routes and fingerprint collection:
+
+```bash
+python main.py serve --port 5000
+```
+
+Run a YAML simulation scenario:
+
+```bash
+python main.py simulate scenario.yml
+```
+
+Reverse shell training (listener or client) can also be defined in scenarios.
+
+Perform passive enrichment for a domain or IP:
+
+```bash
+python main.py enrich --domain example.com
+python main.py enrich --ip 8.8.8.8
+```
+
 ### Configuration
 
 The `~/.lucky7/config.yml` file contains reputation settings. You can provide
@@ -90,3 +117,5 @@ Heuristic lookups consider multiple factors:
 
 * URL checks flag unencrypted links and images larger than the configured threshold.
 * Processes named like telemetry or analytics with outbound traffic are logged with encryption status.
+
+Lucky7 is provided for educational use. Use it only in environments you own or have explicit permission to test.

--- a/automation.py
+++ b/automation.py
@@ -1,0 +1,36 @@
+import yaml
+import time
+import requests
+import reverse_shell
+
+
+def run_scenario(path: str):
+    """Execute a YAML scenario of simulated attacks."""
+    with open(path, 'r') as f:
+        scenario = yaml.safe_load(f) or {}
+
+    for step in scenario.get('steps', []):
+        action = step.get('action')
+        if action == 'delay':
+            time.sleep(step.get('seconds', 1))
+        elif action == 'http_get':
+            url = step.get('url')
+            if url:
+                requests.get(url)
+        elif action == 'http_post':
+            url = step.get('url')
+            data = step.get('data', {})
+            if url:
+                requests.post(url, data=data)
+        elif action == 'reverse_shell':
+            mode = step.get('mode', 'client')
+            host = step.get('host', '127.0.0.1')
+            port = int(step.get('port', 9001))
+            if mode == 'listener':
+                reverse_shell.start_listener(port)
+            else:
+                commands = step.get('commands', [])
+                reverse_shell.simulate_client(host, port, commands)
+        else:
+            print(f"[SIM] Unknown action: {action}")
+

--- a/enrichment.py
+++ b/enrichment.py
@@ -1,0 +1,88 @@
+import json
+from typing import Dict, Any, List
+from datetime import datetime
+
+import requests
+import whois
+from ipwhois import IPWhois
+
+import reputation
+
+
+def whois_lookup(domain: str) -> str:
+    """Return WHOIS text for a domain."""
+    try:
+        data = whois.whois(domain)
+        return data.text if hasattr(data, 'text') else str(data)
+    except Exception as e:
+        return f"error: {e}"
+
+
+def passive_dns(domain: str) -> List[str]:
+    """Retrieve passive DNS hostnames using a public API."""
+    try:
+        resp = requests.get(
+            f"https://api.hackertarget.com/hostsearch/?q={domain}", timeout=10
+        )
+        if resp.status_code == 200:
+            return resp.text.strip().splitlines()
+    except Exception:
+        pass
+    return []
+
+
+def enrich_ip(ip: str, config: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Collect IP info from ipinfo and whois/ASN data."""
+    rep_cfg = (config or {}).get("reputation", {})
+    token = rep_cfg.get("ipinfo_token", "")
+    info: Dict[str, Any] = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+        "ip": ip,
+    }
+
+    # ipinfo lookup
+    ipinfo = reputation._ipinfo_lookup(ip, token)
+    if ipinfo:
+        info["ipinfo"] = ipinfo
+
+    # ASN via ipwhois
+    try:
+        rdap = IPWhois(ip).lookup_rdap()
+        info["asn"] = rdap.get("asn")
+        info["asn_desc"] = rdap.get("asn_description")
+    except Exception:
+        pass
+
+    # optional VT/OTX/AbuseIPDB
+    vt_key = rep_cfg.get("api_key", "").strip()
+    if vt_key:
+        vt = reputation._virustotal_lookup(
+            f"https://www.virustotal.com/api/v3/ip_addresses/{ip}", vt_key
+        )
+        if vt:
+            info["virustotal"] = vt
+    otx_key = rep_cfg.get("otx_api_key", "").strip()
+    if otx_key:
+        otx = reputation._otx_lookup(
+            f"https://otx.alienvault.com/api/v1/indicators/IPv4/{ip}/general",
+            otx_key,
+        )
+        if otx:
+            info["otx"] = otx
+    abuse_key = rep_cfg.get("abuseipdb_key", "").strip()
+    if abuse_key:
+        abuse = reputation._abuseipdb_lookup(ip, abuse_key)
+        if abuse:
+            info["abuseipdb"] = abuse
+    return info
+
+
+def enrich_domain(domain: str, config: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Gather WHOIS and passive DNS for a domain."""
+    result = {
+        "timestamp": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+        "domain": domain,
+        "whois": whois_lookup(domain),
+        "passive_dns": passive_dns(domain),
+    }
+    return result

--- a/main.py
+++ b/main.py
@@ -151,6 +151,29 @@ def check_command(args):
         except FileNotFoundError:
             print(f"[ERROR] File not found: {args.file}")
 
+def serve_command(args):
+    """Run the training web server."""
+    import webapp
+    webapp.app.run(host='0.0.0.0', port=args.port)
+
+
+def simulate_command(args):
+    """Run an attack simulation scenario."""
+    import automation
+    automation.run_scenario(args.file)
+
+
+def enrich_command(args):
+    """Perform passive enrichment for an IP or domain."""
+    cfg = config.load_config() or {}
+    import enrichment
+    if args.ip:
+        info = enrichment.enrich_ip(args.ip, cfg)
+    else:
+        info = enrichment.enrich_domain(args.domain, cfg)
+    import json
+    print(json.dumps(info, indent=2))
+
 def main():
     parser = argparse.ArgumentParser(
         description="Lucky #7 - On-host Monitoring Tool (MVP)"
@@ -177,6 +200,17 @@ def main():
     # Command to score a website for phishing risk
     score_parser = subparsers.add_parser("score", help="Score a website for phishing risk")
     score_parser.add_argument("url", help="URL to evaluate")
+
+    serve_parser = subparsers.add_parser("serve", help="Run training web server")
+    serve_parser.add_argument("--port", type=int, default=5000, help="Port to bind (default 5000)")
+
+    sim_parser = subparsers.add_parser("simulate", help="Run attack simulation scenario")
+    sim_parser.add_argument("file", help="YAML scenario file")
+
+    enrich_parser = subparsers.add_parser("enrich", help="Passive enrichment for an IP or domain")
+    eg = enrich_parser.add_mutually_exclusive_group(required=True)
+    eg.add_argument("--ip", help="IP address to enrich")
+    eg.add_argument("--domain", help="Domain to enrich")
     
     args = parser.parse_args()
     
@@ -192,6 +226,12 @@ def main():
         score_command(args)
     elif args.command == "check":
         check_command(args)
+    elif args.command == "serve":
+        serve_command(args)
+    elif args.command == "simulate":
+        simulate_command(args)
+    elif args.command == "enrich":
+        enrich_command(args)
     else:
         parser.print_help()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests
 pyyaml
 tldextract
 python-whois
+Flask
+ipwhois

--- a/reverse_shell.py
+++ b/reverse_shell.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+import socket
+from datetime import datetime
+from typing import Iterable
+import time
+
+
+def start_listener(port: int = 9001, timeout: int = 30) -> None:
+    """Start a simulated reverse shell listener that logs incoming commands."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("0.0.0.0", port))
+        s.listen(1)
+        s.settimeout(timeout)
+        print(f"[SIM] Reverse shell listener on 0.0.0.0:{port}")
+        try:
+            conn, addr = s.accept()
+        except socket.timeout:
+            print("[SIM] Listener timeout; no connection")
+            return
+        print(f"[SIM] Connection from {addr[0]}:{addr[1]}")
+        with conn:
+            conn.settimeout(timeout)
+            while True:
+                try:
+                    data = conn.recv(1024)
+                except socket.timeout:
+                    print("[SIM] Connection timeout")
+                    break
+                if not data:
+                    break
+                cmd = data.decode(errors="ignore").strip()
+                print(f"[SIM] Received command: {cmd}")
+                conn.sendall(b"OK\n")
+        print("[SIM] Connection closed")
+
+
+def simulate_client(host: str, port: int, commands: Iterable[str], delay: float = 0.5) -> None:
+    """Connect to a listener and send commands for simulation."""
+    with socket.create_connection((host, port), timeout=10) as s:
+        for cmd in commands:
+            print(f"[SIM] Sending: {cmd}")
+            s.sendall(cmd.encode() + b"\n")
+            try:
+                resp = s.recv(1024)
+                print(f"[SIM] Response: {resp.decode(errors='ignore').strip()}")
+            except socket.timeout:
+                print("[SIM] No response")
+            time.sleep(delay)
+

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,150 @@
+from flask import Flask, request, render_template_string
+from datetime import datetime
+import json
+import db
+import reputation
+import config
+
+app = Flask(__name__)
+
+INDEX_HTML = """
+<!doctype html>
+<html>
+<head>
+    <title>Welcome</title>
+    <script src='/fp.js'></script>
+</head>
+<body>
+<h1>Lucky7 Training Server</h1>
+</body>
+</html>
+"""
+
+FINGERPRINT_JS = """
+(async function(){
+    async function sha256(str){
+        const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
+        return Array.from(new Uint8Array(buf)).map(b=>b.toString(16).padStart(2,'0')).join('');
+    }
+    function canvasHash(){
+        try{
+            var c=document.createElement('canvas');
+            var ctx=c.getContext('2d');
+            ctx.textBaseline='top';
+            ctx.font='14px Arial';
+            ctx.fillText('Lucky7',2,2);
+            return sha256(c.toDataURL());
+        }catch(e){return 'nocanvas';}
+    }
+    function webglHash(){
+        var canvas=document.createElement('canvas');
+        var gl=canvas.getContext('webgl')||canvas.getContext('experimental-webgl');
+        if(!gl) return 'nowebgl';
+        var debug=gl.getExtension('WEBGL_debug_renderer_info');
+        var vendor=debug?gl.getParameter(debug.UNMASKED_VENDOR_WEBGL):'';
+        var renderer=debug?gl.getParameter(debug.UNMASKED_RENDERER_WEBGL):'';
+        return sha256(vendor+renderer);
+    }
+    const ua=navigator.userAgent;
+    const scr=screen.width+'x'+screen.height;
+    const tz=(Intl.DateTimeFormat().resolvedOptions().timeZone||'unknown');
+    const platform=navigator.platform;
+    const wh=await webglHash();
+    const ch=await canvasHash();
+    const fp=await sha256(ua+'|'+scr+'|'+tz+'|'+platform+'|'+wh+'|'+ch);
+    const payload={
+        user_agent:ua,
+        screen:scr,
+        timezone:tz,
+        platform:platform,
+        webgl_hash:wh,
+        canvas_hash:ch,
+        fp_hash:fp
+    };
+    fetch('/collect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+})();
+"""
+
+@app.route('/')
+def index():
+    return INDEX_HTML
+
+@app.route('/fp.js')
+def fp_js():
+    return FINGERPRINT_JS, 200, {'Content-Type':'application/javascript'}
+
+@app.route('/collect', methods=['POST'])
+def collect():
+    data = request.get_json() or {}
+    data['timestamp'] = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+    data['ip'] = request.remote_addr
+    db.insert_fingerprint(data)
+    return 'ok'
+
+LOGIN_HTML = """
+<form method='POST'>
+    <input name='username' placeholder='Username'>
+    <input type='password' name='password' placeholder='Password'>
+    <input type='submit' value='Login'>
+</form>
+"""
+
+@app.route('/honeypot/login', methods=['GET','POST'])
+def honeypot_login():
+    if request.method == 'POST':
+        db.insert_honeypot_event({
+            'timestamp': datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'),
+            'ip': request.remote_addr,
+            'endpoint': '/honeypot/login',
+            'method': 'POST',
+            'headers': json.dumps(dict(request.headers)),
+            'data': json.dumps(request.form.to_dict())
+        })
+        return 'Invalid credentials', 401
+    return LOGIN_HTML
+
+@app.route('/download/fake')
+def fake_download():
+    db.insert_honeypot_event({
+        'timestamp': datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'),
+        'ip': request.remote_addr,
+        'endpoint': '/download/fake',
+        'method': 'GET',
+        'headers': json.dumps(dict(request.headers)),
+        'data': ''
+    })
+    return 'File not available', 404
+
+
+BAD_ASN_KEYWORDS = ["amazon", "digitalocean", "ovh", "google", "microsoft", "cloud"]
+
+
+def score_client(ip: str) -> int:
+    """Calculate a simple risk score for an IP."""
+    fp_total = db.count_fingerprints(ip)
+    hp = db.count_honeypot_events(ip)
+    unique = 0
+    for fp_hash in db.get_fingerprint_hashes(ip):
+        if db.count_fingerprint_hash(fp_hash) == 1:
+            unique += 1
+
+    score = fp_total * 5 + hp * 20 + unique * 3
+
+    info = reputation._ipinfo_lookup(
+        ip, config.load_config().get("reputation", {}).get("ipinfo_token", "")
+    )
+    if info:
+        asn = info.get("org", "").lower()
+        if any(k in asn for k in BAD_ASN_KEYWORDS):
+            score += 20
+
+    return score
+
+@app.route('/score')
+def score_endpoint():
+    ip = request.args.get('ip', request.remote_addr)
+    score = score_client(ip)
+    return {'ip': ip, 'score': score}
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add `reverse_shell.py` module with listener and client helpers for simulation
- integrate reverse shell actions into `automation.run_scenario`
- document reverse shell scenario option in README

## Testing
- `python -m py_compile db.py main.py process_monitor.py phishing.py reputation.py webapp.py automation.py enrichment.py reverse_shell.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686a51c2e18483279025cb2bc849e985